### PR TITLE
Updates libthrift to newest version that doesn't require more than th…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
     <!-- common library versions -->
     <slf4j.version>2.0.16</slf4j.version>
-    <libthrift.version>0.13.0</libthrift.version>
+    <libthrift.version>0.20.0</libthrift.version>
     <gson.version>2.8.9</gson.version>
     <gson-extras.version>0.2.2</gson-extras.version>
     <jetty.version>9.4.31.v20200723</jetty.version>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/SupplierWithIO.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/SupplierWithIO.java
@@ -17,9 +17,11 @@
 
 package org.apache.zeppelin.interpreter.remote;
 
+import org.apache.thrift.transport.TTransportException;
+
 import java.io.IOException;
 
 @FunctionalInterface
 public interface SupplierWithIO<T> {
-  T getWithIO() throws IOException;
+  T getWithIO() throws IOException, TTransportException;
 }


### PR DESCRIPTION
…rows change

Seems like this patch was enough. 0.21.0 is incompatible in other ways so using this instead