### PR TITLE
Changed the name of python binary 

### DIFF
--- a/python/src/main/java/com/teragrep/zep_01/python/PythonInterpreter.java
+++ b/python/src/main/java/com/teragrep/zep_01/python/PythonInterpreter.java
@@ -203,7 +203,7 @@ public class PythonInterpreter extends Interpreter {
     } else if (condaPythonExec != null) {
       return condaPythonExec;
     } else {
-      return getProperty("zeppelin.python", "python");
+      return getProperty("zeppelin.python", "python3");
     }
   }
 

--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -8,7 +8,7 @@
       "zeppelin.python": {
         "envName": null,
         "propertyName": "zeppelin.python",
-        "defaultValue": "python",
+        "defaultValue": "python3",
         "description": "Python binary executable path. It is set to python by default.(assume python is in your $PATH)",
         "type": "string"
       },

--- a/python/src/test/java/com/teragrep/zep_01/python/PythonInterpreterMatplotlibTest.java
+++ b/python/src/test/java/com/teragrep/zep_01/python/PythonInterpreterMatplotlibTest.java
@@ -51,7 +51,7 @@ class PythonInterpreterMatplotlibTest implements InterpreterOutputListener {
   @BeforeEach
   public void setUp() throws Exception {
     Properties p = new Properties();
-    p.setProperty("zeppelin.python", "python");
+    p.setProperty("zeppelin.python", "python3");
     p.setProperty("zeppelin.python.maxResult", "100");
     p.setProperty("zeppelin.python.gatewayserver_address", "127.0.0.1");
 


### PR DESCRIPTION
Python binary name changed from python -> python3 to reference the correct name when running PythonInterpreter. Changed all instances of the python.zeppelin property, whether it's as a default value in code or in a configuration file default. Also updated a test that was explicitly setting this property.