### PR TITLE
Add support for multiple admins

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -226,6 +226,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/AuthorizationService.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/AuthorizationService.java
@@ -267,11 +267,13 @@ public class AuthorizationService {
   }
 
   private boolean isAdmin(Set<String> entities) {
-    String adminRole = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_OWNER_ROLE);
-    if (StringUtils.isBlank(adminRole)) {
-      return false;
+    String[] adminRoles = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_OWNER_ROLE).split(",");
+    for (String adminRole : adminRoles) {
+      if(entities.contains(adminRole)){
+        return true;
+      }
     }
-    return entities.contains(adminRole);
+    return false;
   }
 
   // return true if b is empty or if (a intersection b) is non-empty

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
@@ -46,6 +46,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,18 +120,6 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName());
   }
 
-  @FunctionalInterface
-  public interface Executable {
-    void execute() throws Exception;
-  }
-  // This method is a custom JUnit4 implementation of Assertions.assertDoesNotThrow, since JUnit4 does not have a similar built-in method.
-  private void assertNoExceptionIsThrown(Executable executable) {
-    try {
-      executable.execute();
-    } catch (Exception e) {
-      Assert.fail(e.getClass().getSimpleName() + " was thrown");
-    }
-  }
   @Test
   public void testRevisionSupported() throws IOException {
     NotebookRepo notebookRepo;
@@ -1020,7 +1009,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   }
   @Test
   public void testMultipleDefaultAdmins(){
-    assertNoExceptionIsThrown(() -> {
+    Assertions.assertDoesNotThrow(() -> {
       String nonAdminUser = "user1";
       HashSet<String> adminUser = new HashSet<>(Arrays.asList("adminUser"));
       HashSet<String> secondAdmin = new HashSet<>(Arrays.asList("secondAdmin"));
@@ -1029,12 +1018,12 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       conf.setProperty("zeppelin.notebook.default.owner.username", "adminUser,secondAdmin");
 
       // User1 creates a note and sets writer, runner and reader permissions to only themselves.
-      Note note = notebook.createNote("note1",new AuthenticationInfo(nonAdminUser.toString()));
+      Note note = notebook.createNote("note1", new AuthenticationInfo(nonAdminUser.toString()));
 
       System.out.println(authorizationService.getOwners(note.getId()));
-      authorizationService.setReaders(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser)));
-      authorizationService.setRunners(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser)));
-      authorizationService.setWriters(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser)));
+      authorizationService.setReaders(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser)));
+      authorizationService.setRunners(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser)));
+      authorizationService.setWriters(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser)));
 
       // Verify that the original user has access to their own note.
       assertTrue(authorizationService.isOwner(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
@@ -1057,7 +1046,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
   @Test
   public void testNoDefaultAdmins(){
-    assertNoExceptionIsThrown(()->{
+    Assertions.assertDoesNotThrow(()->{
       String nonAdminUser = "user1";
       HashSet<String> adminUser = new HashSet<>(Arrays.asList("adminUser"));
       HashSet<String> secondAdmin = new HashSet<>(Arrays.asList("secondAdmin"));

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
@@ -1040,6 +1040,33 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       assertTrue(authorizationService.isWriter(note.getId(), secondAdmin));
       assertTrue(authorizationService.isRunner(note.getId(), secondAdmin));
   }
+  @Test
+  public void testSingleDefaultAdmin(){
+    String nonAdminUser = "user1";
+    HashSet<String> adminUser = new HashSet<>(Arrays.asList("adminUser"));
+
+    // Set a single admin in configuration file
+    conf.setProperty("zeppelin.notebook.default.owner.username", "adminUser");
+
+    // User1 creates a note and sets writer, runner and reader permissions to only themselves.
+    Note note = Assertions.assertDoesNotThrow(() -> notebook.createNote("note1", new AuthenticationInfo(nonAdminUser.toString())));
+
+    Assertions.assertDoesNotThrow(()->authorizationService.setReaders(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    Assertions.assertDoesNotThrow(()->authorizationService.setRunners(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    Assertions.assertDoesNotThrow(()->authorizationService.setWriters(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+
+    // Verify that the original user has access to their own note.
+    assertTrue(authorizationService.isOwner(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    assertTrue(authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    assertTrue(authorizationService.isWriter(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    assertTrue(authorizationService.isRunner(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+
+    // Only the designated adminUser should have access rights to created note without explicitly giving them access.
+    assertTrue(authorizationService.isOwner(note.getId(), adminUser));
+    assertTrue(authorizationService.isReader(note.getId(), adminUser));
+    assertTrue(authorizationService.isWriter(note.getId(), adminUser));
+    assertTrue(authorizationService.isRunner(note.getId(), adminUser));
+  }
 
   @Test
   public void testNoDefaultAdmins(){

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
@@ -1009,7 +1009,6 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   }
   @Test
   public void testMultipleDefaultAdmins(){
-    Assertions.assertDoesNotThrow(() -> {
       String nonAdminUser = "user1";
       HashSet<String> adminUser = new HashSet<>(Arrays.asList("adminUser"));
       HashSet<String> secondAdmin = new HashSet<>(Arrays.asList("secondAdmin"));
@@ -1017,13 +1016,12 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       // Set multiple admins in configuration file
       conf.setProperty("zeppelin.notebook.default.owner.username", "adminUser,secondAdmin");
 
-      // User1 creates a note and sets writer, runner and reader permissions to only themselves.
-      Note note = notebook.createNote("note1", new AuthenticationInfo(nonAdminUser.toString()));
+    // User1 creates a note and sets writer, runner and reader permissions to only themselves.
+    Note note = Assertions.assertDoesNotThrow(() -> notebook.createNote("note1", new AuthenticationInfo(nonAdminUser.toString())));
 
-      System.out.println(authorizationService.getOwners(note.getId()));
-      authorizationService.setReaders(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser)));
-      authorizationService.setRunners(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser)));
-      authorizationService.setWriters(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser)));
+    Assertions.assertDoesNotThrow(()->authorizationService.setReaders(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    Assertions.assertDoesNotThrow(()->authorizationService.setRunners(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
+    Assertions.assertDoesNotThrow(()->authorizationService.setWriters(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
 
       // Verify that the original user has access to their own note.
       assertTrue(authorizationService.isOwner(note.getId(), new HashSet<>(Arrays.asList(nonAdminUser))));
@@ -1041,12 +1039,10 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       assertTrue(authorizationService.isReader(note.getId(), secondAdmin));
       assertTrue(authorizationService.isWriter(note.getId(), secondAdmin));
       assertTrue(authorizationService.isRunner(note.getId(), secondAdmin));
-    });
   }
 
   @Test
   public void testNoDefaultAdmins(){
-    Assertions.assertDoesNotThrow(()->{
       String nonAdminUser = "user1";
       HashSet<String> adminUser = new HashSet<>(Arrays.asList("adminUser"));
       HashSet<String> secondAdmin = new HashSet<>(Arrays.asList("secondAdmin"));
@@ -1055,10 +1051,10 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       conf.setProperty("zeppelin.notebook.default.owner.username", "");
 
       // User1 creates a note and sets writer, runner and reader permissions to only themselves.
-      Note note = notebook.createNote("note1",new AuthenticationInfo(nonAdminUser));
-      authorizationService.setReaders(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser)));
-      authorizationService.setRunners(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser)));
-      authorizationService.setWriters(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser)));
+      Note note = Assertions.assertDoesNotThrow(()->notebook.createNote("note1",new AuthenticationInfo(nonAdminUser)));
+      Assertions.assertDoesNotThrow(()->authorizationService.setReaders(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser))));
+      Assertions.assertDoesNotThrow(()->authorizationService.setRunners(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser))));
+      Assertions.assertDoesNotThrow(()->authorizationService.setWriters(note.getId(),new HashSet<>(Arrays.asList(nonAdminUser))));
 
 
       // Neither adminUser should have any access rights to created note
@@ -1071,7 +1067,6 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       assertFalse(authorizationService.isReader(note.getId(), secondAdmin));
       assertFalse(authorizationService.isWriter(note.getId(), secondAdmin));
       assertFalse(authorizationService.isRunner(note.getId(), secondAdmin));
-    });
   }
 
   @Test


### PR DESCRIPTION
See pagure link in comments for original peer-review comments

Resolves #105
## Description
It's now allowed to specify multiple default notebook admins in a comma-separated list within the zeppelin.notebook.default.owner.username in zeppelin-site.xml.

Admin users will be identified by matching their username or shiro role to the values specified in zeppelin-site.xml.

These users can see every notebook in the UI, regardless of the permissions that have been set to the notebooks.

## Checklists

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29). - No new objects are created, only primitive Strings are used.
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
