### PR TITLE
Issue 86 websocket session confusion

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -344,6 +344,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/ConnectionManager.java
@@ -172,21 +172,21 @@ public class ConnectionManager {
     }
   }
 
+  // Sends a response message indicating whether or not the notebook in question has multiple users connected, and lists the usernames of the connected users
   private void checkCollaborativeStatus(String noteId, List<NotebookSocket> socketList) {
     if (!collaborativeModeEnable) {
       return;
     }
-    boolean collaborativeStatusNew = socketList.size() > 1;
-    if (collaborativeStatusNew) {
+    boolean collaborativeStatus = socketList.size() > 1;
+    if (collaborativeStatus) {
       Message message = new Message(Message.OP.COLLABORATIVE_MODE_STATUS);
-      message.put("status", collaborativeStatusNew);
-      if (collaborativeStatusNew) {
-        HashSet<String> userList = new HashSet<>();
-        for (NotebookSocket noteSocket : socketList) {
-          userList.add(noteSocket.getUser());
-        }
-        message.put("users", userList);
+      message.put("status", collaborativeStatus);
+      // Create a list of users for the response
+      HashSet<String> userList = new HashSet<>();
+      for (NotebookSocket noteSocket : socketList) {
+        userList.add(noteSocket.getUser());
       }
+      message.put("users", userList);
       broadcast(noteId, message);
     }
   }

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/ConnectionManager.java
@@ -168,19 +168,8 @@ public class ConnectionManager {
     synchronized (noteSocketMap) {
       Set<String> noteIds = noteSocketMap.keySet();
       for (String noteId : noteIds) {
-        removeConnectionFromNote(noteId, socket);
+        removeNoteConnection(noteId, socket);
       }
-    }
-  }
-
-  private void removeConnectionFromNote(String noteId, NotebookSocket socket) {
-    LOGGER.debug("Remove connection {} from note: {}", socket, noteId);
-    synchronized (noteSocketMap) {
-      List<NotebookSocket> socketList = noteSocketMap.get(noteId);
-      if (socketList != null) {
-        socketList.remove(socket);
-      }
-      checkCollaborativeStatus(noteId, socketList);
     }
   }
 

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
@@ -687,7 +687,6 @@ public class NotebookServerTest extends AbstractTestRestApi {
 
   @Test
   public void testCollaborativeModeStatus() {
-    Assertions.assertDoesNotThrow(()->{
       NotebookSocket sock1 = createWebSocket();
       NotebookSocket sock2 = createWebSocket();
       NotebookSocket sock3 = createWebSocket();
@@ -707,16 +706,10 @@ public class NotebookServerTest extends AbstractTestRestApi {
                       .put("name", noteName)
                       .put("defaultInterpreterId", defaultInterpreterId).toJson());
 
-      String noteId = "";
-      for (Note note : notebook.getAllNotes()) {
-        if (note.getName().equals(noteName)) {
-          noteId = note.getId();
-          break;
-        }
-        else {
-          Assertions.fail();
-        }
-      }
+    Assertions.assertDoesNotThrow(()-> {
+      // Make sure there is only one created notebook, and get its' ID.
+      Assertions.assertEquals(1,notebook.getAllNotes().size());
+      String noteId = notebook.getAllNotes().get(0).getId();
 
       // Expect correct number of COLLABORATIVE_MODE_STATUS messages when a number of users join the same notebook.
       notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
@@ -724,15 +717,15 @@ public class NotebookServerTest extends AbstractTestRestApi {
 
       // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
       verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-      notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
-              .put("id",noteId).toJson());
+      notebookServer.onMessage(sock2, new Message(OP.GET_NOTE)
+              .put("id", noteId).toJson());
 
       // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
       verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
       verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
 
-      notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
-              .put("id",noteId).toJson());
+      notebookServer.onMessage(sock3, new Message(OP.GET_NOTE)
+              .put("id", noteId).toJson());
 
       // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 3 joins
       verify(sock1, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
@@ -744,7 +737,6 @@ public class NotebookServerTest extends AbstractTestRestApi {
 
   @Test
   public void testCollaborativeModeBetweenNotebooks() {
-    Assertions.assertDoesNotThrow(()->{
       NotebookSocket sock1 = createWebSocket();
       NotebookSocket sock2 = createWebSocket();
       NotebookSocket sock3 = createWebSocket();
@@ -752,6 +744,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.onOpen(sock2);
       notebookServer.onOpen(sock3);
 
+    Assertions.assertDoesNotThrow(()->{
       String noteName = "Note with millis " + System.currentTimeMillis();
       String defaultInterpreterId = "";
       List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
@@ -764,13 +757,9 @@ public class NotebookServerTest extends AbstractTestRestApi {
                       .put("name", noteName)
                       .put("defaultInterpreterId", defaultInterpreterId).toJson());
 
-      String noteId = "";
-      for (Note note : notebook.getAllNotes()) {
-        if (note.getName().equals(noteName)) {
-          noteId = note.getId();
-          break;
-        }
-      }
+      // Make sure there is only one created notebook, and get its' ID.
+      Assertions.assertEquals(1,notebook.getAllNotes().size());
+      String noteId = notebook.getAllNotes().get(0).getId();
 
       // create another note from sock1
       String note2Name = "Note with millis " + System.currentTimeMillis();

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
@@ -686,125 +686,129 @@ public class NotebookServerTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testCollaborativeModeStatus() throws IOException {
-    NotebookSocket sock1 = createWebSocket();
-    NotebookSocket sock2 = createWebSocket();
-    NotebookSocket sock3 = createWebSocket();
-    notebookServer.onOpen(sock1);
-    notebookServer.onOpen(sock2);
-    notebookServer.onOpen(sock3);
+  public void testCollaborativeModeStatus() {
+    Assertions.assertDoesNotThrow(()->{
+      NotebookSocket sock1 = createWebSocket();
+      NotebookSocket sock2 = createWebSocket();
+      NotebookSocket sock3 = createWebSocket();
+      notebookServer.onOpen(sock1);
+      notebookServer.onOpen(sock2);
+      notebookServer.onOpen(sock3);
 
-    String noteName = "Note with millis " + System.currentTimeMillis();
-    String defaultInterpreterId = "";
-    List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
-    if (settings.size() > 1) {
-      defaultInterpreterId = settings.get(0).getId();
-    }
-    // create note from sock1
-    notebookServer.onMessage(sock1,
-            new Message(OP.NEW_NOTE)
-                    .put("name", noteName)
-                    .put("defaultInterpreterId", defaultInterpreterId).toJson());
-
-    String noteId = "";
-    for (Note note : notebook.getAllNotes()) {
-      if (note.getName().equals(noteName)) {
-        noteId = note.getId();
-        break;
+      String noteName = "Note with millis " + System.currentTimeMillis();
+      String defaultInterpreterId = "";
+      List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
+      if (settings.size() > 1) {
+        defaultInterpreterId = settings.get(0).getId();
       }
-      else {
-        Assertions.fail();
+      // create note from sock1
+      notebookServer.onMessage(sock1,
+              new Message(OP.NEW_NOTE)
+                      .put("name", noteName)
+                      .put("defaultInterpreterId", defaultInterpreterId).toJson());
+
+      String noteId = "";
+      for (Note note : notebook.getAllNotes()) {
+        if (note.getName().equals(noteName)) {
+          noteId = note.getId();
+          break;
+        }
+        else {
+          Assertions.fail();
+        }
       }
-    }
 
-    // Expect correct number of COLLABORATIVE_MODE_STATUS messages when a number of users join the same notebook.
-    notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
-            .put("id",noteId).toJson());
+      // Expect correct number of COLLABORATIVE_MODE_STATUS messages when a number of users join the same notebook.
+      notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
+              .put("id",noteId).toJson());
 
-    // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
-    verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
-            .put("id",noteId).toJson());
+      // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
+      verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
+              .put("id",noteId).toJson());
 
-    // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
-    verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
+      verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
 
-    notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
-            .put("id",noteId).toJson());
+      notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
+              .put("id",noteId).toJson());
 
-    // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 3 joins
-    verify(sock1, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    verify(sock2, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    // User 3 should be notified about the other users by a COLLABORATIVE_MODE_STATUS message upon joining
-    verify(sock3, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 3 joins
+      verify(sock1, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      verify(sock2, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      // User 3 should be notified about the other users by a COLLABORATIVE_MODE_STATUS message upon joining
+      verify(sock3, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    });
   }
 
   @Test
-  public void testCollaborativeModeBetweenNotebooks() throws IOException {
-    NotebookSocket sock1 = createWebSocket();
-    NotebookSocket sock2 = createWebSocket();
-    NotebookSocket sock3 = createWebSocket();
-    notebookServer.onOpen(sock1);
-    notebookServer.onOpen(sock2);
-    notebookServer.onOpen(sock3);
+  public void testCollaborativeModeBetweenNotebooks() {
+    Assertions.assertDoesNotThrow(()->{
+      NotebookSocket sock1 = createWebSocket();
+      NotebookSocket sock2 = createWebSocket();
+      NotebookSocket sock3 = createWebSocket();
+      notebookServer.onOpen(sock1);
+      notebookServer.onOpen(sock2);
+      notebookServer.onOpen(sock3);
 
-    String noteName = "Note with millis " + System.currentTimeMillis();
-    String defaultInterpreterId = "";
-    List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
-    if (settings.size() > 1) {
-      defaultInterpreterId = settings.get(0).getId();
-    }
-    // create note from sock1
-    notebookServer.onMessage(sock1,
-            new Message(OP.NEW_NOTE)
-                    .put("name", noteName)
-                    .put("defaultInterpreterId", defaultInterpreterId).toJson());
-
-    String noteId = "";
-    for (Note note : notebook.getAllNotes()) {
-      if (note.getName().equals(noteName)) {
-        noteId = note.getId();
-        break;
+      String noteName = "Note with millis " + System.currentTimeMillis();
+      String defaultInterpreterId = "";
+      List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
+      if (settings.size() > 1) {
+        defaultInterpreterId = settings.get(0).getId();
       }
-    }
+      // create note from sock1
+      notebookServer.onMessage(sock1,
+              new Message(OP.NEW_NOTE)
+                      .put("name", noteName)
+                      .put("defaultInterpreterId", defaultInterpreterId).toJson());
 
-    // create another note from sock1
-    String note2Name = "Note with millis " + System.currentTimeMillis();
-    notebookServer.onMessage(sock1,
-            new Message(OP.NEW_NOTE)
-                    .put("name", note2Name)
-                    .put("defaultInterpreterId", defaultInterpreterId).toJson());
-
-    String note2Id = "";
-    for (Note note : notebook.getAllNotes()) {
-      if (note.getName().equals(note2Name)) {
-        note2Id = note.getId();
-        break;
+      String noteId = "";
+      for (Note note : notebook.getAllNotes()) {
+        if (note.getName().equals(noteName)) {
+          noteId = note.getId();
+          break;
+        }
       }
-    }
 
-    // Expect no COLLABORATIVE_MODE_STATUS messages when users join an unrelated notebook.
-    notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
-            .put("id",noteId).toJson());
+      // create another note from sock1
+      String note2Name = "Note with millis " + System.currentTimeMillis();
+      notebookServer.onMessage(sock1,
+              new Message(OP.NEW_NOTE)
+                      .put("name", note2Name)
+                      .put("defaultInterpreterId", defaultInterpreterId).toJson());
 
-    // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
-    verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
-            .put("id",noteId).toJson());
+      String note2Id = "";
+      for (Note note : notebook.getAllNotes()) {
+        if (note.getName().equals(note2Name)) {
+          note2Id = note.getId();
+          break;
+        }
+      }
 
-    // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
-    verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      // Expect no COLLABORATIVE_MODE_STATUS messages when users join an unrelated notebook.
+      notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
+              .put("id",noteId).toJson());
 
-    notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
-            .put("id",note2Id).toJson());
+      // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
+      verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
+              .put("id",noteId).toJson());
 
-    // Both users 1 and 2 shouldn't receive a COLLABORATIVE_MODE_STATUS message when user 3 joins some other notebook
-    verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    // User 3 should not get a COLLABORATIVE_MODE_STATUS message upon joining their own separate notebook
-    verify(sock3, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
+      verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+
+      notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
+              .put("id",note2Id).toJson());
+
+      // Both users 1 and 2 shouldn't receive a COLLABORATIVE_MODE_STATUS message when user 3 joins some other notebook
+      verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      // User 3 should not get a COLLABORATIVE_MODE_STATUS message upon joining their own separate notebook
+      verify(sock3, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    });
   }
 
   private NotebookSocket createWebSocket() {

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
@@ -706,7 +706,6 @@ public class NotebookServerTest extends AbstractTestRestApi {
                       .put("name", noteName)
                       .put("defaultInterpreterId", defaultInterpreterId).toJson());
 
-    Assertions.assertDoesNotThrow(()-> {
       // Make sure there is only one created notebook, and get its' ID.
       Assertions.assertEquals(1,notebook.getAllNotes().size());
       String noteId = notebook.getAllNotes().get(0).getId();
@@ -716,23 +715,21 @@ public class NotebookServerTest extends AbstractTestRestApi {
               .put("id",noteId).toJson());
 
       // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
-      verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+
+      Assertions.assertDoesNotThrow(()-> verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
       notebookServer.onMessage(sock2, new Message(OP.GET_NOTE)
               .put("id", noteId).toJson());
-
-      // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
-      verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-      verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+        // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
+      Assertions.assertDoesNotThrow(()-> verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
+      Assertions.assertDoesNotThrow(()-> verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
 
       notebookServer.onMessage(sock3, new Message(OP.GET_NOTE)
               .put("id", noteId).toJson());
-
       // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 3 joins
-      verify(sock1, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-      verify(sock2, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      Assertions.assertDoesNotThrow(()-> verify(sock1, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
+      Assertions.assertDoesNotThrow(()-> verify(sock2, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
       // User 3 should be notified about the other users by a COLLABORATIVE_MODE_STATUS message upon joining
-      verify(sock3, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    });
+      Assertions.assertDoesNotThrow(()-> verify(sock3, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
   }
 
   @Test
@@ -744,7 +741,6 @@ public class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.onOpen(sock2);
       notebookServer.onOpen(sock3);
 
-    Assertions.assertDoesNotThrow(()->{
       String noteName = "Note with millis " + System.currentTimeMillis();
       String defaultInterpreterId = "";
       List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
@@ -781,23 +777,22 @@ public class NotebookServerTest extends AbstractTestRestApi {
               .put("id",noteId).toJson());
 
       // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
-      verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      Assertions.assertDoesNotThrow(()-> verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
       notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
               .put("id",noteId).toJson());
 
       // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
-      verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-      verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      Assertions.assertDoesNotThrow(()-> verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
+      Assertions.assertDoesNotThrow(()-> verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
 
       notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
               .put("id",note2Id).toJson());
 
       // Both users 1 and 2 shouldn't receive a COLLABORATIVE_MODE_STATUS message when user 3 joins some other notebook
-      verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-      verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+      Assertions.assertDoesNotThrow(()-> verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
+      Assertions.assertDoesNotThrow(()-> verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
       // User 3 should not get a COLLABORATIVE_MODE_STATUS message upon joining their own separate notebook
-      verify(sock3, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
-    });
+      Assertions.assertDoesNotThrow(()-> verify(sock3, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString())));
   }
 
   private NotebookSocket createWebSocket() {

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -72,6 +73,7 @@ import com.teragrep.zep_01.service.ServiceContext;
 import com.teragrep.zep_01.user.AuthenticationInfo;
 import com.teragrep.zep_01.utils.TestUtils;
 import org.junit.*;
+import org.junit.jupiter.api.Assertions;
 
 
 /** Basic REST API tests for notebookServer. */
@@ -681,6 +683,128 @@ public class NotebookServerTest extends AbstractTestRestApi {
     // checkout the first commit
     note = notebook.getNoteByRevision(note.getId(), note.getPath(), firstRevision.id, AuthenticationInfo.ANONYMOUS);
     assertEquals(0, note.getParagraphCount());
+  }
+
+  @Test
+  public void testCollaborativeModeStatus() throws IOException {
+    NotebookSocket sock1 = createWebSocket();
+    NotebookSocket sock2 = createWebSocket();
+    NotebookSocket sock3 = createWebSocket();
+    notebookServer.onOpen(sock1);
+    notebookServer.onOpen(sock2);
+    notebookServer.onOpen(sock3);
+
+    String noteName = "Note with millis " + System.currentTimeMillis();
+    String defaultInterpreterId = "";
+    List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
+    if (settings.size() > 1) {
+      defaultInterpreterId = settings.get(0).getId();
+    }
+    // create note from sock1
+    notebookServer.onMessage(sock1,
+            new Message(OP.NEW_NOTE)
+                    .put("name", noteName)
+                    .put("defaultInterpreterId", defaultInterpreterId).toJson());
+
+    String noteId = "";
+    for (Note note : notebook.getAllNotes()) {
+      if (note.getName().equals(noteName)) {
+        noteId = note.getId();
+        break;
+      }
+      else {
+        Assertions.fail();
+      }
+    }
+
+    // Expect correct number of COLLABORATIVE_MODE_STATUS messages when a number of users join the same notebook.
+    notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
+            .put("id",noteId).toJson());
+
+    // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
+    verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
+            .put("id",noteId).toJson());
+
+    // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
+    verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+
+    notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
+            .put("id",noteId).toJson());
+
+    // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 3 joins
+    verify(sock1, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    verify(sock2, times(2)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    // User 3 should be notified about the other users by a COLLABORATIVE_MODE_STATUS message upon joining
+    verify(sock3, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+  }
+
+  @Test
+  public void testCollaborativeModeBetweenNotebooks() throws IOException {
+    NotebookSocket sock1 = createWebSocket();
+    NotebookSocket sock2 = createWebSocket();
+    NotebookSocket sock3 = createWebSocket();
+    notebookServer.onOpen(sock1);
+    notebookServer.onOpen(sock2);
+    notebookServer.onOpen(sock3);
+
+    String noteName = "Note with millis " + System.currentTimeMillis();
+    String defaultInterpreterId = "";
+    List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
+    if (settings.size() > 1) {
+      defaultInterpreterId = settings.get(0).getId();
+    }
+    // create note from sock1
+    notebookServer.onMessage(sock1,
+            new Message(OP.NEW_NOTE)
+                    .put("name", noteName)
+                    .put("defaultInterpreterId", defaultInterpreterId).toJson());
+
+    String noteId = "";
+    for (Note note : notebook.getAllNotes()) {
+      if (note.getName().equals(noteName)) {
+        noteId = note.getId();
+        break;
+      }
+    }
+
+    // create another note from sock1
+    String note2Name = "Note with millis " + System.currentTimeMillis();
+    notebookServer.onMessage(sock1,
+            new Message(OP.NEW_NOTE)
+                    .put("name", note2Name)
+                    .put("defaultInterpreterId", defaultInterpreterId).toJson());
+
+    String note2Id = "";
+    for (Note note : notebook.getAllNotes()) {
+      if (note.getName().equals(note2Name)) {
+        note2Id = note.getId();
+        break;
+      }
+    }
+
+    // Expect no COLLABORATIVE_MODE_STATUS messages when users join an unrelated notebook.
+    notebookServer.onMessage(sock1,new Message(OP.GET_NOTE)
+            .put("id",noteId).toJson());
+
+    // User 1 shouldn't get a COLLABORATIVE_MODE_STATUS message when they join as the first user
+    verify(sock1, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    notebookServer.onMessage(sock2,new Message(OP.GET_NOTE)
+            .put("id",noteId).toJson());
+
+    // Both users 1 and 2 should receive a COLLABORATIVE_MODE_STATUS message when user 2 joins so that they both know about each other.
+    verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+
+    notebookServer.onMessage(sock3,new Message(OP.GET_NOTE)
+            .put("id",note2Id).toJson());
+
+    // Both users 1 and 2 shouldn't receive a COLLABORATIVE_MODE_STATUS message when user 3 joins some other notebook
+    verify(sock1, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    verify(sock2, times(1)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
+    // User 3 should not get a COLLABORATIVE_MODE_STATUS message upon joining their own separate notebook
+    verify(sock3, times(0)).send(contains(OP.COLLABORATIVE_MODE_STATUS.toString()));
   }
 
   private NotebookSocket createWebSocket() {


### PR DESCRIPTION
## Description

Moved the emission of COLLABORATIVE_MODE_STATUS messages so that they are only called when the connected users have actually changed. This should remove the COLLABORATIVE_MODE_STATUS updates being sent to other notebooks.

## Checklists

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
