### PR TITLE
add null check for gson parsed AjaxRequest before validation

### DIFF
--- a/spark/dpl-interpreter/src/main/java/com/teragrep/pth_07/ui/elements/table_dynamic/AJAXRequestWatcher.java
+++ b/spark/dpl-interpreter/src/main/java/com/teragrep/pth_07/ui/elements/table_dynamic/AJAXRequestWatcher.java
@@ -82,7 +82,8 @@ public class AJAXRequestWatcher extends AngularObjectWatcher {
         AJAXRequest ajaxRequest = gson.fromJson((String) o1, AJAXRequest.class);
 
         // validate request
-        if (ajaxRequest.getDraw() != null
+        if (ajaxRequest != null
+                && ajaxRequest.getDraw() != null
                 && ajaxRequest.getStart() != null
                 && ajaxRequest.getLength() != null
                 && ajaxRequest.getSearch() != null


### PR DESCRIPTION
Coverity 1560164 Dereference null return value

Migrated from https://github.com/teragrep/pth_07/pull/47