### PR TITLE
check that a spark interpreter from zeppelin is not null

### DIFF
--- a/spark/dpl-interpreter/src/main/java/com/teragrep/pth_07/DPLInterpreter.java
+++ b/spark/dpl-interpreter/src/main/java/com/teragrep/pth_07/DPLInterpreter.java
@@ -101,6 +101,11 @@ public class DPLInterpreter extends AbstractInterpreter {
         LOGGER.info("DPL-interpreter Open(): {}", properties);
 
         sparkInterpreter = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class, true);
+
+        if (sparkInterpreter == null) {
+            throw new InterpreterException("Could not find open SparkInterpreter in the same interpreter group from session by class name");
+        }
+
         sparkContext = sparkInterpreter.getSparkContext();
 
         // increase open counter


### PR DESCRIPTION
Coverity 1560166 Dereference null return value

Migrated from https://github.com/teragrep/pth_07/pull/50