### PR TITLE
Issue 109 spark conf doesnt always apply configuration

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -226,6 +226,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/interpreter/ConfInterpreter.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/interpreter/ConfInterpreter.java
@@ -64,21 +64,23 @@ public class ConfInterpreter extends Interpreter {
       throws InterpreterException {
 
     try {
-      Properties finalProperties = new Properties();
-      finalProperties.putAll(getProperties());
+      // Read user-given properties into a Properties object.
       Properties newProperties = new Properties();
       newProperties.load(new StringReader(st));
-      finalProperties.putAll(newProperties);
-      LOGGER.debug("Properties for InterpreterGroup: {} is {}", interpreterGroupId, finalProperties);
-      interpreterSetting.setInterpreterGroupProperties(interpreterGroupId, finalProperties);
-      String msg = "";
-      if(newProperties.entrySet().size() > 0){
-        msg = "New properties set! Properties for " + interpreterGroupId + " are now:\n";
-        for(Map.Entry property : finalProperties.entrySet()){
-          msg = msg + property.getKey() + " = " +property.getValue() + "\n";
-        }
+
+      // First put any existing properties into a new Properties object, then update it with new user-given properties, and apply the combined properties to the InterpreterSetting.
+      Properties combinedProperties = new Properties();
+      combinedProperties.putAll(getProperties());
+      combinedProperties.putAll(newProperties);
+      interpreterSetting.setInterpreterGroupProperties(interpreterGroupId, combinedProperties);
+
+      // Create a response message containing the updated list of properties.
+      StringBuilder message = new StringBuilder();
+      message.append("Properties set! Properties for " + interpreterGroupId + " are:\n");
+      for(Map.Entry property : combinedProperties.entrySet()){
+        message.append(property.getKey() + " = " +property.getValue() + "\n");
       }
-      return new InterpreterResult(InterpreterResult.Code.SUCCESS,msg);
+      return new InterpreterResult(InterpreterResult.Code.SUCCESS,message.toString());
     } catch (IOException e) {
       LOGGER.error("Fail to update interpreter setting", e);
       return new InterpreterResult(InterpreterResult.Code.ERROR, ExceptionUtils.getStackTrace(e));

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/interpreter/ConfInterpreter.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/interpreter/ConfInterpreter.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -70,7 +71,14 @@ public class ConfInterpreter extends Interpreter {
       finalProperties.putAll(newProperties);
       LOGGER.debug("Properties for InterpreterGroup: {} is {}", interpreterGroupId, finalProperties);
       interpreterSetting.setInterpreterGroupProperties(interpreterGroupId, finalProperties);
-      return new InterpreterResult(InterpreterResult.Code.SUCCESS);
+      String msg = "";
+      if(newProperties.entrySet().size() > 0){
+        msg = "New properties set! Properties for " + interpreterGroupId + " are now:\n";
+        for(Map.Entry property : finalProperties.entrySet()){
+          msg = msg + property.getKey() + " = " +property.getValue() + "\n";
+        }
+      }
+      return new InterpreterResult(InterpreterResult.Code.SUCCESS,msg);
     } catch (IOException e) {
       LOGGER.error("Fail to update interpreter setting", e);
       return new InterpreterResult(InterpreterResult.Code.ERROR, ExceptionUtils.getStackTrace(e));

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/interpreter/ConfInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/interpreter/ConfInterpreterTest.java
@@ -117,7 +117,6 @@ public class ConfInterpreterTest extends AbstractInterpreterTest {
       assertTrue(result.toString().contains("property_3 = value_3"));
       assertTrue(result.toString().contains("property_2 = new_value_2"));
       assertTrue(result.toString().contains("property_1 = new_value"));
-      System.out.println(result);
     });
   }
 }

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/interpreter/ConfInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/interpreter/ConfInterpreterTest.java
@@ -20,6 +20,7 @@ package com.teragrep.zep_01.interpreter;
 import com.teragrep.zep_01.interpreter.remote.RemoteInterpreter;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -97,4 +98,26 @@ public class ConfInterpreterTest extends AbstractInterpreterTest {
     assertEquals(InterpreterResult.Code.ERROR, result.code);
   }
 
+  // Running confInterpreter should print out the currently used properties
+  @Test
+  public void testPrintingCurrentConfiguration(){
+    Assertions.assertDoesNotThrow(()->{
+      assertTrue(interpreterFactory.getInterpreter("test.conf", executionContext) instanceof ConfInterpreter);
+      ConfInterpreter confInterpreter = (ConfInterpreter) interpreterFactory.getInterpreter("test.conf", executionContext);
+
+      InterpreterContext context = InterpreterContext.builder()
+              .setNoteId("noteId")
+              .setParagraphId("paragraphId")
+              .build();
+
+      InterpreterResult result = confInterpreter.interpret("property_1\tnew_value\nnew_property\tdummy_value", context);
+      assertEquals(InterpreterResult.Code.SUCCESS, result.code);
+      assertTrue(result.toString().contains("New properties set! Properties for "+confInterpreter.getInterpreterGroup().getId()+" are now:"));
+      assertTrue(result.toString().contains("new_property = dummy_value"));
+      assertTrue(result.toString().contains("property_3 = value_3"));
+      assertTrue(result.toString().contains("property_2 = new_value_2"));
+      assertTrue(result.toString().contains("property_1 = new_value"));
+      System.out.println(result);
+    });
+  }
 }

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/interpreter/ConfInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/interpreter/ConfInterpreterTest.java
@@ -110,9 +110,10 @@ public class ConfInterpreterTest extends AbstractInterpreterTest {
               .setParagraphId("paragraphId")
               .build();
 
+      // Assign a new value to one of the properties and create one new property, should result in a message listing out all existing properties properly updated as well as the new property.
       InterpreterResult result = confInterpreter.interpret("property_1\tnew_value\nnew_property\tdummy_value", context);
       assertEquals(InterpreterResult.Code.SUCCESS, result.code);
-      assertTrue(result.toString().contains("New properties set! Properties for "+confInterpreter.getInterpreterGroup().getId()+" are now:"));
+      assertTrue(result.toString().contains("Properties for "+confInterpreter.getInterpreterGroup().getId()+" are:"));
       assertTrue(result.toString().contains("new_property = dummy_value"));
       assertTrue(result.toString().contains("property_3 = value_3"));
       assertTrue(result.toString().contains("property_2 = new_value_2"));


### PR DESCRIPTION
See pagure link in comments for original peer-review comments
## Description
Running a ConfInterpreter now responds with the properties to indicate that properties have been set.
<!-- Please include a summary of changes made in your pull request. -->

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
