### PR TITLE
Add better variance of default options for bloom filter fields

### DIFF
--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -675,7 +675,7 @@
         "type": "checkbox"
       },
       "dpl.pth_06.bloom.db.fields": {
-        "defaultValue": "[{expected: 100000, fpp: 0.01},{expected: 1000000, fpp: 0.03},{expected: 2500000, fpp: 0.05}]",
+        "defaultValue": "[{expected: 10, fpp: 0.01},{expected: 100, fpp: 0.01},{expected: 1000, fpp: 0.01},{expected: 10000, fpp: 0.01},{expected: 1000000, fpp: 0.01},{expected: 2500000, fpp: 0.01}]",
         "description": "Configure number of filter fields and expected num of items and fpp ",
         "envName": "",
         "propertyName": "dpl.pth_06.bloom.db.fields",


### PR DESCRIPTION
Add sizes 10, 100, 1000.
Lower 100000 to 10000 and use false positive to 0.01 on all the filters.

These values better reflect the expected sizes after the implementation of regex matching bloom filtering.

Migrated from https://github.com/teragrep/pth_07/pull/54

Edit to inject_config.json from original Pull request omitted as inject_config.json does not exist in ZEP_01