### PR TITLE
Added a configuration variable to SparkInterpreters, which allows DTTableDatasetNg to create JSON data in the format expected by the UI

### DIFF
--- a/spark/interpreter/src/main/java/com/teragrep/zep_01/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/com/teragrep/zep_01/spark/SparkInterpreter.java
@@ -120,6 +120,8 @@ public class SparkInterpreter extends AbstractInterpreter {
                   masterEnv == null ? SparkStringConstants.DEFAULT_MASTER_VALUE : masterEnv);
         }
       }
+      // Set Sparks JSON generation setting to include null values to satisfy UI's DataTables.js requirements for drawing tables.
+      conf.set("spark.sql.jsonGenerator.ignoreNullFields","false");
       this.innerInterpreter = loadSparkScalaInterpreter(conf);
       this.innerInterpreter.open();
 

--- a/spark/interpreter/src/main/java/com/teragrep/zep_01/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/com/teragrep/zep_01/spark/SparkInterpreter.java
@@ -120,8 +120,6 @@ public class SparkInterpreter extends AbstractInterpreter {
                   masterEnv == null ? SparkStringConstants.DEFAULT_MASTER_VALUE : masterEnv);
         }
       }
-      // Set Sparks JSON generation setting to include null values to satisfy UI's DataTables.js requirements for drawing tables.
-      conf.set("spark.sql.jsonGenerator.ignoreNullFields","false");
       this.innerInterpreter = loadSparkScalaInterpreter(conf);
       this.innerInterpreter.open();
 

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -143,6 +143,13 @@
         "defaultValue": true,
         "description": "Whether show the spark deprecated message, spark 2.2 and before are deprecated. Zeppelin will display warning message by default",
         "type": "checkbox"
+      },
+      "spark.sql.jsonGenerator.ignoreNullFields": {
+        "envName": null,
+        "propertyName": "spark.sql.jsonGenerator.ignoreNullFields",
+        "defaultValue": false,
+        "description": " Whether to discard null values when generating JSON from a Spark Dataset. Warning: toggling this to 'true' may cause issues with displaying data in paragraphs!",
+        "type": "checkbox"
       }
     },
     "editor": {

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -148,7 +148,7 @@
         "envName": null,
         "propertyName": "spark.sql.jsonGenerator.ignoreNullFields",
         "defaultValue": false,
-        "description": " Whether to discard null values when generating JSON from a Spark Dataset. Warning: toggling this to 'true' may cause issues with displaying data in paragraphs!",
+        "description": "Whether to discard null values when generating JSON from a Spark Dataset. Warning: toggling this to 'true' may cause issues with displaying data in paragraphs!",
         "type": "checkbox"
       }
     },


### PR DESCRIPTION
## Description
Added "spark.sql.jsonGenerator.ignoreNullFields = false" configuration value to enable including null values in Spark objects' .toJson() method. This overrides the default value of 'true' if the configuration value is not set.

This is done to ensure that DTTableDatasetNg can provide data to UI in the correct format expected by the UI.

Users should not change this configuration value, as doing so will cause UI to throw errors when missing keys are printed, but it is regardless available in interpreter-setting.json if for some reason changing it is necessary.

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
