### PR TITLE
Fix to results being reset after pagination update.

### DIFF
--- a/spark/dpl-interpreter/src/main/java/com/teragrep/pth_07/ui/elements/table_dynamic/DTTableDatasetNg.java
+++ b/spark/dpl-interpreter/src/main/java/com/teragrep/pth_07/ui/elements/table_dynamic/DTTableDatasetNg.java
@@ -114,7 +114,7 @@ public final class DTTableDatasetNg extends AbstractUserInterfaceElement {
             int length = ajaxRequest.getJsonNumber("length").intValue();
             int draw = ajaxRequest.getJsonNumber("draw").intValue();
             String searchString = ajaxRequest.getJsonObject("search").getString("value");
-            updatePage(start,length,searchString, draw);
+            updatePage(start,length,searchString, draw, false);
         }
         finally {
             lock.unlock();
@@ -150,7 +150,7 @@ public final class DTTableDatasetNg extends AbstractUserInterfaceElement {
                 DTHeader dtHeader = new DTHeader(rowDataset.schema());
                 schemaHeadersJson = dtHeader.json();
                 datasetAsJSON = rowDataset.toJSON().collectAsList();
-                updatePage(0,currentAJAXLength,"",1);
+                updatePage(0,currentAJAXLength,"",1,true);
             }
         } finally {
             lock.unlock();
@@ -158,7 +158,7 @@ public final class DTTableDatasetNg extends AbstractUserInterfaceElement {
     }
 
     // Sends a PARAGRAPH_UPDATE_OUTPUT message to UI containing the paginated data
-    private void updatePage(int start, int length, String searchString, int draw){
+    private void updatePage(int start, int length, String searchString, int draw, boolean clearParagraphResults){
         if (datasetAsJSON == null) {
             LOGGER.warn("attempting to draw empty dataset");
             return;
@@ -167,7 +167,7 @@ public final class DTTableDatasetNg extends AbstractUserInterfaceElement {
             JsonObject response = SearchAndPaginate(draw, start,length,searchString);
             String outputContent = "%jsontable\n" +
                     response.toString();
-            getInterpreterContext().out().clear();
+            getInterpreterContext().out().clear(clearParagraphResults);
             getInterpreterContext().out().write(outputContent);
             getInterpreterContext().out().flush();
         } catch (java.io.IOException e) {

--- a/spark/dpl-interpreter/src/test/java/com/teragrep/pth_07/ui/elements/table_dynamic/DTTableDatasetNgTest.java
+++ b/spark/dpl-interpreter/src/test/java/com/teragrep/pth_07/ui/elements/table_dynamic/DTTableDatasetNgTest.java
@@ -84,6 +84,41 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DTTableDatasetNgTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(DTTableDatasetNgTest.class);
+    private final SparkSession sparkSession = SparkSession.builder()
+            .master("local[*]")
+            .config("spark.cleaner.referenceTracking.cleanCheckpoints", "true")
+            .config("checkpointLocation","/tmp/pth_10/test/StackTest/checkpoints/" + UUID.randomUUID() + "/")
+            .config("spark.sql.session.timeZone", "UTC")
+            .getOrCreate();
+    private final StructType testSchema = new StructType(
+            new StructField[] {
+                    new StructField("_time", DataTypes.TimestampType, false, new MetadataBuilder().build()),
+                    new StructField("id", DataTypes.LongType, false, new MetadataBuilder().build()),
+                    new StructField("_raw", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("index", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("sourcetype", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("host", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("source", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("partition", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("offset", DataTypes.LongType, false, new MetadataBuilder().build()),
+                    new StructField("origin", DataTypes.StringType, false, new MetadataBuilder().build())
+            }
+    );
+    private final List<Row> rows = makeRowsList(
+            0L, 				// _time
+            0L, 					// id
+            "data data", 			// _raw
+            "index_A", 				// index
+            "stream", 				// sourcetype
+            "host", 				// host
+            "input", 				// source
+            String.valueOf(0), 	    // partition
+            0L, 				    // offset
+            "test data",            // origin
+            49                     // make n amount of rows
+    );
+
+    Dataset<Row> testDs = sparkSession.createDataFrame(rows, testSchema);
 
     @Test
     public void parseAsPojo() {
@@ -172,43 +207,6 @@ public class DTTableDatasetNgTest {
 
     @Test
     public void testAJAXResponse() {
-       StructType testSchema = new StructType(
-                new StructField[] {
-                        new StructField("_time", DataTypes.TimestampType, false, new MetadataBuilder().build()),
-                        new StructField("id", DataTypes.LongType, false, new MetadataBuilder().build()),
-                        new StructField("_raw", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("index", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("sourcetype", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("host", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("source", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("partition", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("offset", DataTypes.LongType, false, new MetadataBuilder().build()),
-                        new StructField("origin", DataTypes.StringType, false, new MetadataBuilder().build())
-                }
-        );
-
-        SparkSession sparkSession = SparkSession.builder()
-                .master("local[*]")
-                .config("spark.cleaner.referenceTracking.cleanCheckpoints", "true")
-                .config("checkpointLocation","/tmp/pth_10/test/StackTest/checkpoints/" + UUID.randomUUID() + "/")
-                .config("spark.sql.session.timeZone", "UTC")
-                .getOrCreate();
-
-        List<Row> rows = makeRowsList(
-                0L, 				// _time
-                0L, 					// id
-                "data data", 			// _raw
-                "index_A", 				// index
-                "stream", 				// sourcetype
-                "host", 				// host
-                "input", 				// source
-                String.valueOf(0), 	    // partition
-                0L, 				    // offset
-                "test data",            // origin
-                49                     // make n amount of rows
-        );
-
-        Dataset<Row> testDs = sparkSession.createDataFrame(rows, testSchema);
         List<String> datasetAsJSON = testDs.toJSON().collectAsList();
 
         List<String> subList = datasetAsJSON.subList(0, 5);
@@ -317,43 +315,6 @@ public class DTTableDatasetNgTest {
         InterpreterContext context = InterpreterContext.builder().setInterpreterOut(testOutput).setAngularObjectRegistry(testRegistry).build();
         DTTableDatasetNg dtTableDatasetNg = new DTTableDatasetNg(context);
 
-        StructType testSchema = new StructType(
-                new StructField[] {
-                        new StructField("_time", DataTypes.TimestampType, false, new MetadataBuilder().build()),
-                        new StructField("id", DataTypes.LongType, false, new MetadataBuilder().build()),
-                        new StructField("_raw", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("index", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("sourcetype", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("host", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("source", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("partition", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("offset", DataTypes.LongType, false, new MetadataBuilder().build()),
-                        new StructField("origin", DataTypes.StringType, false, new MetadataBuilder().build())
-                }
-        );
-
-        SparkSession sparkSession = SparkSession.builder()
-                .master("local[*]")
-                .config("spark.cleaner.referenceTracking.cleanCheckpoints", "true")
-                .config("checkpointLocation","/tmp/pth_10/test/StackTest/checkpoints/" + UUID.randomUUID() + "/")
-                .config("spark.sql.session.timeZone", "UTC")
-                .getOrCreate();
-        List<Row> rows = makeRowsList(
-                0L, 				// _time
-                0L, 					// id
-                "data data", 			// _raw
-                "index_A", 				// index
-                "stream", 				// sourcetype
-                "host", 				// host
-                "input", 				// source
-                String.valueOf(0), 	    // partition
-                0L, 				    // offset
-                "test data",            // origin
-                49                     // make n amount of rows
-        );
-
-        Dataset<Row> testDs = sparkSession.createDataFrame(rows, testSchema);
-
         // Simulate DPL receiving new data.
         Assertions.assertDoesNotThrow(()->{
             dtTableDatasetNg.setParagraphDataset(testDs);
@@ -367,52 +328,16 @@ public class DTTableDatasetNgTest {
     // Does not include a concrete implementation of InterpreterOutputListener as it's an anonymous class within RemoteInterpreterServer, and instantiating it would require too many dependencies.
     @Test
     public void testNoClearParagraphResultsOnPaginationRequest(){
-        StructType testSchema = new StructType(
-                new StructField[] {
-                        new StructField("_time", DataTypes.TimestampType, false, new MetadataBuilder().build()),
-                        new StructField("id", DataTypes.LongType, false, new MetadataBuilder().build()),
-                        new StructField("_raw", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("index", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("sourcetype", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("host", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("source", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("partition", DataTypes.StringType, false, new MetadataBuilder().build()),
-                        new StructField("offset", DataTypes.LongType, false, new MetadataBuilder().build()),
-                        new StructField("origin", DataTypes.StringType, false, new MetadataBuilder().build())
-                }
-        );
 
-        SparkSession sparkSession = SparkSession.builder()
-                .master("local[*]")
-                .config("spark.cleaner.referenceTracking.cleanCheckpoints", "true")
-                .config("checkpointLocation","/tmp/pth_10/test/StackTest/checkpoints/" + UUID.randomUUID() + "/")
-                .config("spark.sql.session.timeZone", "UTC")
-                .getOrCreate();
-        List<Row> rows = makeRowsList(
-                0L, 				// _time
-                0L, 					// id
-                "data data", 			// _raw
-                "index_A", 				// index
-                "stream", 				// sourcetype
-                "host", 				// host
-                "input", 				// source
-                String.valueOf(0), 	    // partition
-                0L, 				    // offset
-                "test data",            // origin
-                49                     // make n amount of rows
-        );
-
-        Dataset<Row> testDs = sparkSession.createDataFrame(rows, testSchema);
         TestInterpreterOutputListener listener = new TestInterpreterOutputListener();
         InterpreterOutput testOutput =  new InterpreterOutput(listener);
 
         AngularObjectRegistry testRegistry = new AngularObjectRegistry("test", null);
-
-        testRegistry.add("testAO","baseValue","testNote","testParagraph");
         InterpreterContext context = InterpreterContext.builder().setInterpreterOut(testOutput).setAngularObjectRegistry(testRegistry).setNoteId("testNote").setParagraphId("testParagraph").build();
         DTTableDatasetNg dtTableDatasetNg = new DTTableDatasetNg(context);
-        dtTableDatasetNg.setParagraphDataset(testDs);
-
+        Assertions.assertDoesNotThrow(()->{
+            dtTableDatasetNg.setParagraphDataset(testDs);
+        });
         AngularObject testAo = context.getAngularObjectRegistry().get("AJAXRequest_testParagraph","testNote","testParagraph");
         String ajaxRequestString = "{\"draw\":1,\"columns\":[{\"data\":0,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":1,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":2,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":3,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":4,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":5,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":6,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}},{\"data\":7,\"name\":\"\",\"searchable\":true,\"orderable\":true,\"search\":{\"value\":\"\",\"regex\":false}}],\"order\":[{\"column\":0,\"dir\":\"desc\"},{\"column\":0,\"dir\":\"asc\"}],\"start\":0,\"length\":5,\"search\":{\"value\":\"\",\"regex\":false}}";
         // Simulate DPL receiving new data.


### PR DESCRIPTION
## Description

Fixes results being cleared after a successful pagination request.
1. Call to getInterpreterContext().out().clear() in DTTableDatasetNg causes a reset to Paragraph.results.

2. getInterpreterContext().out().flush() on the other hand does not update Paragraph.results, it updates Paragraph.outputBuffer.

3. The data sent to ui comes from Paragraph.results, which was previously cleared, leading to results being dropped.

When running a paragraph, the Paragraph.result is set by Job.completeWithSuccess() -> Job.setResult() method, which is not used when pagination is changed.

Since the source of truth in Zeppelin is the state of the Note object in memory, empty Paragraph.result also is saved to disk when another change is made.

This fix works by providing a boolean to the already defined getInterpreterContext().out().clear() method. Providing true clears the results (wanted behaviour when paragraph is executed) Providing false skips the call to clear results (wanted behaviour when changing pagination)

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [ ] I have checked that my test files and functions have meaningful names.
- [ ] I have checked that each test tests only a single behavior.
- [ ] I have done happy tests.
- [ ] I have tested only my own code.
- [ ] I have tested at least all public methods.

#### Assertions

- [ ] I have checked that my tests use assertions and not runtime overhead.
- [ ] I have checked that my tests end in assertions.
- [ ] I have checked that there is no comparison statements in assertions.
- [ ] I have checked that assertions are in tests and not in helper functions.
- [ ] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [ ] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [ ] I have tested algorithms and anything else with the possibility of unbound growth.
- [ ] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [ ] I have checked that all test files are standalone.
- [ ] I have checked that all test-specific fake objects and classes are in the test directory.
- [ ] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [ ] I have checked that my tests do not contain non-generic information.
- [ ] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [ ] I have checked that my tests do not use throws for exceptions.
- [ ] I have checked that my tests do not use try-catch statements.
- [ ] I have checked that my tests do not use if-else statements.

#### Java

- [ ] I have checked that my tests for Java uses JUnit library.
- [ ] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [ ] I have only tested public behavior and not private implementation details.
- [ ] I have checked that my tests are not (partially) commented out.
- [ ] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [ ] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [ ] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Object Quality.
- [ ] I have checked that my code does not have any NULL values.
- [ ] I have checked my code does not contain FIXME or TODO comments.
