### PR TITLE
Issue 271 support for arbitrary text to top banner

### DIFF
--- a/zeppelin-interpreter/src/main/java/com/teragrep/zep_01/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/com/teragrep/zep_01/conf/ZeppelinConfiguration.java
@@ -1025,7 +1025,8 @@ public class ZeppelinConfiguration {
     ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10 * 1000),
     ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS("zeppelin.note.file.exclude.fields", ""),
     ZEPPELIN_RESOURCEPOOL_MAX_OBJECT_SIZE("zeppelin.resourcepool.max.object.size", 10 * 1024),
-    ZEPPELIN_RESOURCEPOOL_MAX_OBJECT_COUNT("zeppelin.resourcepool.max.object.count", 1000);
+    ZEPPELIN_RESOURCEPOOL_MAX_OBJECT_COUNT("zeppelin.resourcepool.max.object.count", 1000),
+    ZEPPELIN_ANNOUNCEMENT("zeppelin.announcement","");
 
     private String varName;
     private Class<?> varClass;

--- a/zeppelin-interpreter/src/main/java/com/teragrep/zep_01/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/com/teragrep/zep_01/conf/ZeppelinConfiguration.java
@@ -1026,7 +1026,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS("zeppelin.note.file.exclude.fields", ""),
     ZEPPELIN_RESOURCEPOOL_MAX_OBJECT_SIZE("zeppelin.resourcepool.max.object.size", 10 * 1024),
     ZEPPELIN_RESOURCEPOOL_MAX_OBJECT_COUNT("zeppelin.resourcepool.max.object.count", 1000),
-    ZEPPELIN_ANNOUNCEMENT("zeppelin.announcement","");
+    ZEPPELIN_ANNOUNCEMENT("zeppelin.announcement", "");
 
     private String varName;
     private Class<?> varClass;

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -483,6 +483,7 @@
           </excludes>
           <environmentVariables>
             <ZEPPELIN_FORCE_STOP>1</ZEPPELIN_FORCE_STOP>
+            <ZEPPELIN_ANNOUNCEMENT>This is a default text value for an announcement</ZEPPELIN_ANNOUNCEMENT>
           </environmentVariables>
         </configuration>
       </plugin>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -483,7 +483,6 @@
           </excludes>
           <environmentVariables>
             <ZEPPELIN_FORCE_STOP>1</ZEPPELIN_FORCE_STOP>
-            <ZEPPELIN_ANNOUNCEMENT>This is a default text value for an announcement</ZEPPELIN_ANNOUNCEMENT>
           </environmentVariables>
         </configuration>
       </plugin>

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
@@ -62,15 +62,17 @@ public class ZeppelinRestApi {
     versionInfo.put("version", Util.getVersion());
     versionInfo.put("git-commit-id", Util.getGitCommitId());
     versionInfo.put("git-timestamp", Util.getGitTimestamp());
-
     return new JsonResponse<>(Response.Status.OK, "Zeppelin version", versionInfo).build();
   }
 
   @GET
-  @Path("banner")
+  @Path("announcement")
   @ZeppelinApi
-  public Response getBanner() {
-    return new JsonResponse<>(Response.Status.OK, "Top banner text", "ZEPPELIN BANNER").build();
+  public Response getAnnouncement() {
+    Map<String, String> json = new HashMap<>();
+    String envValue = System.getenv("ZEPPELIN_ANNOUNCEMENT");
+    json.put("announcement", envValue);
+    return new JsonResponse<>(Response.Status.OK, json).build();
   }
 
   /**

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
@@ -97,7 +97,7 @@ public class ZeppelinRestApi {
    */
   @PUT
   @Path("announcement")
-  public Response setAnnouncement(@Context final HttpServletRequest request) {
+  public Response putAnnouncement(@Context final HttpServletRequest request) {
     Response response;
     final String envAnnouncement = System.getenv(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName());
     try(final BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))){

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
@@ -66,6 +66,13 @@ public class ZeppelinRestApi {
     return new JsonResponse<>(Response.Status.OK, "Zeppelin version", versionInfo).build();
   }
 
+  @GET
+  @Path("banner")
+  @ZeppelinApi
+  public Response getBanner() {
+    return new JsonResponse<>(Response.Status.OK, "Top banner text", "ZEPPELIN BANNER").build();
+  }
+
   /**
    * Set the log level for root logger.
    *

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class ZeppelinRestApi {
 
-  org.slf4j.Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+  private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ZeppelinRestApi.class);
 
   /**
    * Get the root endpoint Return always 200.
@@ -81,9 +81,10 @@ public class ZeppelinRestApi {
   @Path("announcement")
   @ZeppelinApi
   public Response getAnnouncement() {
-    Map<String, String> json = new HashMap<>();
+    final Map<String, String> json = new HashMap<>();
     // Searches first from Environment variables, if a match is not found, searches from zeppelin-site.xml, if a match is not found, returns a default value.
-    String announcementText = ZeppelinConfiguration.create().getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT);
+    final ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    final String announcementText = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT);
     json.put("announcement", announcementText);
     return new JsonResponse<>(Response.Status.OK, json).build();
   }
@@ -91,17 +92,17 @@ public class ZeppelinRestApi {
   /**
    * Set a new value for announcement text. Does not override announcement texts from Environment variables (set via zeppelin-env.sh)
    *
-   * @param request
-   * @return
+   * @param request Request should contain a payload in its body. Payload content will be set as the announcement text.
+   * @return Responds with a message indicating whether the operation resulted in an updated announcement text or not.
    */
   @PUT
   @Path("announcement")
-  public Response setAnnouncement(@Context HttpServletRequest request) {
+  public Response setAnnouncement(@Context final HttpServletRequest request) {
     Response response;
-    String envAnnouncement = System.getenv(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName());
-    try(BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))){
+    final String envAnnouncement = System.getenv(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName());
+    try(final BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))){
       if(envAnnouncement == null){
-        StringBuilder body = new StringBuilder();
+        final StringBuilder body = new StringBuilder();
           String line;
           while ((line = reader.readLine()) != null){
             body.append(line);

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
@@ -97,18 +97,27 @@ public class ZeppelinRestApi {
   @PUT
   @Path("announcement")
   public Response setAnnouncement(@Context HttpServletRequest request) {
-    StringBuilder body = new StringBuilder();
+    Response response;
+    String envAnnouncement = System.getenv(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName());
     try(BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))){
-      String line;
-      while ((line = reader.readLine()) != null){
-        body.append(line);
-      }
-      System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName(),body.toString());
-    } catch (IOException e) {
-      LOGGER.error("Error while setting announcement text!",e);
-        return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR).build();
+      if(envAnnouncement == null){
+        StringBuilder body = new StringBuilder();
+          String line;
+          while ((line = reader.readLine()) != null){
+            body.append(line);
+          }
+          System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName(),body.toString());
+          response = new JsonResponse<>(Response.Status.OK,"Announcement text set successfully").build();
+        }
+        else {
+          response = new JsonResponse<>(Response.Status.BAD_REQUEST,"Announcement already set via environment variable!").build();
+        }
     }
-    return new JsonResponse<>(Response.Status.OK,"Announcement text set successfully").build();
+    catch (IOException e) {
+      LOGGER.error("Error while setting announcement text!",e);
+      response = new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+    return response;
   }
 
   /**

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/rest/ZeppelinRestApi.java
@@ -17,6 +17,7 @@
 package com.teragrep.zep_01.rest;
 
 import javax.inject.Singleton;
+import com.teragrep.zep_01.conf.ZeppelinConfiguration;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
@@ -70,8 +71,9 @@ public class ZeppelinRestApi {
   @ZeppelinApi
   public Response getAnnouncement() {
     Map<String, String> json = new HashMap<>();
-    String envValue = System.getenv("ZEPPELIN_ANNOUNCEMENT");
-    json.put("announcement", envValue);
+    // Searches first from Environment variables, if a match is not found, searches from zeppelin-site.xml, if a match is not found, returns a default value.
+    String announcementText = ZeppelinConfiguration.create().getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT);
+    json.put("announcement", announcementText);
     return new JsonResponse<>(Response.Status.OK, json).build();
   }
 

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/AbstractTestRestApi.java
@@ -141,6 +141,7 @@ public abstract class AbstractTestRestApi {
   protected static File zeppelinHome;
   protected static File confDir;
   protected static File notebookDir;
+  protected static final String testAnnouncement = "Test announcement for Zeppelin";
 
   private static CloseableHttpClient httpClient;
 
@@ -213,6 +214,8 @@ public abstract class AbstractTestRestApi {
               new File("target/zeppelin-web-angular/dist").getAbsolutePath());
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_CONF_DIR.getVarName(),
           confDir.getAbsolutePath());
+      System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANNOUNCEMENT.getVarName(),
+              testAnnouncement);
       System.setProperty(
           ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_DEFAULT.getVarName(),
           "spark");

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
@@ -93,10 +93,10 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   // A GET request to /api/announcement should return the currently set announcement configuration value.
   @Test
   public void getAnnouncementTextTest() throws IOException {
-    CloseableHttpResponse get = httpGet("/announcement");
-    String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
+    final CloseableHttpResponse get = httpGet("/announcement");
+    final String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
     get.close();
-    JsonObject expectedResponse = Json.createObjectBuilder()
+    final JsonObject expectedResponse = Json.createObjectBuilder()
             .add("status","OK")
             .add("body",Json.createObjectBuilder()
                     .add("announcement",ZeppelinConfiguration.create().getString(ConfVars.ZEPPELIN_ANNOUNCEMENT))
@@ -108,15 +108,15 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   // A PUT request with a plain text body to /api/announcement should set the announcement configuration value.
   @Test
   public void setAnnouncementTextTest() throws IOException {
-    String editedAnnouncementText = "A new announcement just dropped!";
+    final String editedAnnouncementText = "A new announcement just dropped!";
     // Announcement variable should not be set to desired value at the start.
     Assertions.assertNotEquals(editedAnnouncementText, ZeppelinConfiguration.create().getString(ConfVars.ZEPPELIN_ANNOUNCEMENT));
-    CloseableHttpResponse put = httpPut("/announcement", editedAnnouncementText);
-    String putResponse = EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8);
+    final CloseableHttpResponse put = httpPut("/announcement", editedAnnouncementText);
+    final String putResponse = EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8);
     put.close();
 
     // Request should receive the appropriate response
-    JsonObject expectedResponse = Json.createObjectBuilder()
+    final JsonObject expectedResponse = Json.createObjectBuilder()
             .add("status","OK")
             .add("message","Announcement text set successfully")
             .build();

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import com.teragrep.zep_01.conf.ZeppelinConfiguration;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
@@ -89,20 +90,20 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     httpGetRoot.close();
   }
 
-  // Requires environment value "ZEPPELIN_ANNOUNCEMENT" to be set. Currently set in zeppelin-server/pom.xml
+  // A GET request to /api/announcement should return the currently set announcement configuration value.
   @Test
-  public void announcementTest() throws IOException {
-      CloseableHttpResponse get = httpGet("/announcement");
-      String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
-      get.close();
-      JsonObject expectedResponse = Json.createObjectBuilder()
-              .add("status","OK")
-              .add("body",Json.createObjectBuilder()
-                      .add("announcement",System.getenv("ZEPPELIN_ANNOUNCEMENT"))
-                      .build())
-              .build();
-      Assertions.assertEquals(expectedResponse.toString(),getResponse);
-    }
+  public void getAnnouncementTextTest() throws IOException {
+    CloseableHttpResponse get = httpGet("/announcement");
+    String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
+    get.close();
+    JsonObject expectedResponse = Json.createObjectBuilder()
+            .add("status","OK")
+            .add("body",Json.createObjectBuilder()
+                    .add("announcement",ZeppelinConfiguration.create().getString(ConfVars.ZEPPELIN_ANNOUNCEMENT))
+                    .build())
+            .build();
+    Assertions.assertEquals(expectedResponse.toString(),getResponse);
+  }
 
   @Test
   @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.fail;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -34,6 +36,7 @@ import com.teragrep.zep_01.notebook.Notebook;
 import com.teragrep.zep_01.rest.message.NoteJobStatus;
 import com.teragrep.zep_01.utils.TestUtils;
 import org.junit.*;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
@@ -53,7 +56,6 @@ import com.teragrep.zep_01.user.AuthenticationInfo;
 /**
  * BASIC Zeppelin rest api tests.
  */
-@Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZeppelinRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
@@ -77,6 +79,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   /**
    * ROOT API TEST.
    **/
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   @Test
   public void getApiRoot() throws IOException {
     // when
@@ -86,7 +89,23 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     httpGetRoot.close();
   }
 
+  // Requires environment value "ZEPPELIN_ANNOUNCEMENT" to be set. Currently set in zeppelin-server/pom.xml
   @Test
+  public void announcementTest() throws IOException {
+      CloseableHttpResponse get = httpGet("/announcement");
+      String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
+      get.close();
+      JsonObject expectedResponse = Json.createObjectBuilder()
+              .add("status","OK")
+              .add("body",Json.createObjectBuilder()
+                      .add("announcement",System.getenv("ZEPPELIN_ANNOUNCEMENT"))
+                      .build())
+              .build();
+      Assertions.assertEquals(expectedResponse.toString(),getResponse);
+    }
+
+  @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testGetNoteInfo() throws IOException {
     LOG.debug("testGetNoteInfo");
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
@@ -121,17 +140,20 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testNoteCreateWithName() throws IOException {
     String noteName = "Test note name";
     testNoteCreate(noteName);
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testNoteCreateNoName() throws IOException {
     testNoteCreate("");
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testNoteCreateWithParagraphs() throws IOException {
     // Call Create Note REST API
     String noteName = "test";
@@ -208,6 +230,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testDeleteNote() throws IOException {
     LOG.debug("testDeleteNote");
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testDeletedNote", anonymous);
@@ -216,12 +239,14 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testDeleteNoteBadId() throws IOException {
     LOG.debug("testDeleteNoteBadId");
     testDeleteNotExistNote("bad_ID");
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testExportNote() throws IOException {
     LOG.debug("testExportNote");
 
@@ -252,6 +277,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testImportNotebook() throws IOException {
     Map<String, Object> resp;
     String oldJson;
@@ -321,6 +347,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testCloneNote() throws IOException, IllegalArgumentException {
     LOG.debug("testCloneNote");
     // Create note to clone
@@ -357,6 +384,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testListNotes() throws IOException {
     LOG.debug("testListNotes");
     CloseableHttpResponse get = httpGet("/notebook/");
@@ -374,6 +402,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testNoteJobs() throws Exception {
     LOG.debug("testNoteJobs");
 
@@ -425,6 +454,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testGetNoteJob() throws Exception {
     LOG.debug("testGetNoteJob");
 
@@ -470,6 +500,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testRunParagraphWithParams() throws Exception {
     LOG.debug("testRunParagraphWithParams");
 
@@ -503,6 +534,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testJobs() throws Exception {
     // create a note and a paragraph
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
@@ -544,6 +576,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testCronDisable() throws Exception {
     // create a note and a paragraph
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "false");
@@ -585,6 +618,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testRegressionZEPPELIN_527() throws Exception {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testRegressionZEPPELIN_527", anonymous);
     note.setName("note for run test");
@@ -604,6 +638,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testInsertParagraph() throws IOException {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testInsertParagraph", anonymous);
 
@@ -661,6 +696,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testUpdateParagraph() throws IOException {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testUpdateParagraph", anonymous);
 
@@ -702,6 +738,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testGetParagraph() throws IOException {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testGetParagraph", anonymous);
 
@@ -730,6 +767,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testMoveParagraph() throws IOException {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testMoveParagraph", anonymous);
 
@@ -762,6 +800,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testDeleteParagraph() throws IOException {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testDeleteParagraph", anonymous);
 
@@ -781,6 +820,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testTitleSearch() throws IOException, InterruptedException {
     Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testTitleSearch", anonymous);
     String jsonRequest = "{\"title\": \"testTitleSearchOfParagraph\", " +

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/rest/ZeppelinRestApiTest.java
@@ -105,6 +105,26 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Assertions.assertEquals(expectedResponse.toString(),getResponse);
   }
 
+  // A PUT request with a plain text body to /api/announcement should set the announcement configuration value.
+  @Test
+  public void setAnnouncementTextTest() throws IOException {
+    String editedAnnouncementText = "A new announcement just dropped!";
+    // Announcement variable should not be set to desired value at the start.
+    Assertions.assertNotEquals(editedAnnouncementText, ZeppelinConfiguration.create().getString(ConfVars.ZEPPELIN_ANNOUNCEMENT));
+    CloseableHttpResponse put = httpPut("/announcement", editedAnnouncementText);
+    String putResponse = EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8);
+    put.close();
+
+    // Request should receive the appropriate response
+    JsonObject expectedResponse = Json.createObjectBuilder()
+            .add("status","OK")
+            .add("message","Announcement text set successfully")
+            .build();
+    Assertions.assertEquals(expectedResponse.toString(),putResponse);
+    // Announcement variable should be set to desired value after successful request.
+    Assertions.assertEquals(editedAnnouncementText, ZeppelinConfiguration.create().getString(ConfVars.ZEPPELIN_ANNOUNCEMENT));
+  }
+
   @Test
   @Ignore(value="Flaky tests: HttpHostConnect Connect to localhost:8080 [localhost/127.0.0.1] failed: Connection refused (Connection refused) or Task com.teragrep.zep_01.notebook.NoteEventAsyncListener$EventHandling@1eea9d2d rejected from java.util.concurrent.ThreadPoolExecutor@29182679")
   public void testGetNoteInfo() throws IOException {


### PR DESCRIPTION
## Description
closes #271
Adds support for an announcement text to be set and retrieved from server

The announcement text is stored as a configuration value, and can be set in the same way as any other configuration value: via environment variables (Set via zeppelin-env.sh) or via System properties (can be set via API endpoints), prioritizing environment variables.
 
Includes a new API endpoint /api/announcement, supporting GET and PUT requests. These allow for retrieving or setting the System property for announcement text, respectively.

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
