### PR TITLE
Issue 330 version histroy cleared on notebook rename

### DIFF
--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/service/NotebookService.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 
+import com.teragrep.zep_01.notebook.repo.Revision;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
@@ -829,11 +830,11 @@ public class NotebookService {
     callback.onSuccess(note, context);
   }
 
-  public NotebookRepoWithVersionControl.Revision checkpointNote(
+  public Revision checkpointNote(
       String noteId,
       String commitMessage,
       ServiceContext context,
-      ServiceCallback<NotebookRepoWithVersionControl.Revision> callback) throws IOException {
+      ServiceCallback<Revision> callback) throws IOException {
 
     Note note = notebook.getNote(noteId);
     if (note == null) {
@@ -846,16 +847,16 @@ public class NotebookService {
       return null;
     }
 
-    NotebookRepoWithVersionControl.Revision revision =
+    Revision revision =
         notebook.checkpointNote(noteId, note.getPath(), commitMessage, context.getAutheInfo());
     callback.onSuccess(revision, context);
     return revision;
   }
 
-  public List<NotebookRepoWithVersionControl.Revision> listRevisionHistory(
+  public List<Revision> listRevisionHistory(
       String noteId,
       ServiceContext context,
-      ServiceCallback<List<NotebookRepoWithVersionControl.Revision>> callback) throws IOException {
+      ServiceCallback<List<Revision>> callback) throws IOException {
 
     Note note = notebook.getNote(noteId);
     if (note == null) {
@@ -869,7 +870,7 @@ public class NotebookService {
     //        callback)) {
     //      return null;
     //    }
-    List<NotebookRepoWithVersionControl.Revision> revisions =
+    List<Revision> revisions =
         notebook.listRevisionHistory(noteId, note.getPath(), context.getAutheInfo());
     callback.onSuccess(revisions, context);
     return revisions;

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/NotebookServer.java
@@ -1570,7 +1570,7 @@ public class NotebookServer extends WebSocketServlet
           @Override
           public void onSuccess(Revision revision, ServiceContext context) throws IOException {
             super.onSuccess(revision, context);
-            if (!revision.isEmpty()) {
+            if (revision != null && !revision.isEmpty()) {
               List<Revision> revisions =
                   getNotebook().listRevisionHistory(noteId, getNotebook().getNote(noteId).getPath(),
                       context.getAutheInfo());

--- a/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/com/teragrep/zep_01/socket/NotebookServer.java
@@ -55,7 +55,7 @@ import com.teragrep.zep_01.notebook.NotebookImportDeserializer;
 import com.teragrep.zep_01.notebook.Paragraph;
 import com.teragrep.zep_01.notebook.ParagraphJobListener;
 import com.teragrep.zep_01.notebook.AuthorizationService;
-import com.teragrep.zep_01.notebook.repo.NotebookRepoWithVersionControl.Revision;
+import com.teragrep.zep_01.notebook.repo.Revision;
 import com.teragrep.zep_01.common.Message;
 import com.teragrep.zep_01.common.Message.OP;
 import com.teragrep.zep_01.rest.exception.ForbiddenException;
@@ -1570,7 +1570,7 @@ public class NotebookServer extends WebSocketServlet
           @Override
           public void onSuccess(Revision revision, ServiceContext context) throws IOException {
             super.onSuccess(revision, context);
-            if (!Revision.isEmpty(revision)) {
+            if (!revision.isEmpty()) {
               List<Revision> revisions =
                   getNotebook().listRevisionHistory(noteId, getNotebook().getNote(noteId).getPath(),
                       context.getAutheInfo());

--- a/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/com/teragrep/zep_01/socket/NotebookServerTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.teragrep.zep_01.notebook.repo.Revision;
 import org.apache.commons.io.IOUtils;
 import org.apache.thrift.TException;
 import com.teragrep.zep_01.conf.ZeppelinConfiguration;
@@ -661,8 +662,8 @@ public class NotebookServerTest extends AbstractTestRestApi {
   public void testNoteRevision() throws IOException {
     Note note = notebook.createNote("note1", anonymous);
     assertEquals(0, note.getParagraphCount());
-    NotebookRepoWithVersionControl.Revision firstRevision = notebook.checkpointNote(note.getId(), note.getPath(), "first commit", AuthenticationInfo.ANONYMOUS);
-    List<NotebookRepoWithVersionControl.Revision> revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
+    Revision firstRevision = notebook.checkpointNote(note.getId(), note.getPath(), "first commit", AuthenticationInfo.ANONYMOUS);
+    List<Revision> revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
     assertEquals(1, revisionList.size());
     assertEquals(firstRevision.id, revisionList.get(0).id);
     assertEquals("first commit", revisionList.get(0).message);
@@ -671,7 +672,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     notebook.saveNote(note, AuthenticationInfo.ANONYMOUS);
     assertEquals(1, note.getParagraphCount());
-    NotebookRepoWithVersionControl.Revision secondRevision = notebook.checkpointNote(note.getId(), note.getPath(), "second commit", AuthenticationInfo.ANONYMOUS);
+    Revision secondRevision = notebook.checkpointNote(note.getId(), note.getPath(), "second commit", AuthenticationInfo.ANONYMOUS);
 
     revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
     assertEquals(2, revisionList.size());

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -221,6 +221,13 @@
     </dependency>
 
     <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.17.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>${google.truth.version}</version>

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/Notebook.java
@@ -48,7 +48,7 @@ import com.teragrep.zep_01.interpreter.ManagedInterpreterGroup;
 import com.teragrep.zep_01.notebook.repo.NotebookRepo;
 import com.teragrep.zep_01.notebook.repo.NotebookRepoSync;
 import com.teragrep.zep_01.notebook.repo.NotebookRepoWithVersionControl;
-import com.teragrep.zep_01.notebook.repo.NotebookRepoWithVersionControl.Revision;
+import com.teragrep.zep_01.notebook.repo.Revision;
 import com.teragrep.zep_01.scheduler.Job;
 import com.teragrep.zep_01.user.AuthenticationInfo;
 import com.teragrep.zep_01.user.Credentials;
@@ -440,7 +440,7 @@ public class Notebook {
   }
 
   public Revision checkpointNote(String noteId, String notePath, String checkpointMessage,
-      AuthenticationInfo subject) throws IOException {
+                                 AuthenticationInfo subject) throws IOException {
     if (((NotebookRepoSync) notebookRepo).isRevisionSupportedInDefaultRepo()) {
       return ((NotebookRepoWithVersionControl) notebookRepo)
           .checkpoint(noteId, notePath, checkpointMessage, subject);

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
@@ -90,9 +90,9 @@ public class GitNotebookRepo extends VFSNotebookRepo implements NotebookRepoWith
     super.move(noteId, notePath, newNotePath, subject);
     String noteFileName = buildNoteFileName(noteId, notePath);
     String newNoteFileName = buildNoteFileName(noteId, newNotePath);
-    git.rm().addFilepattern(noteFileName);
-    git.add().addFilepattern(newNoteFileName);
     try {
+      git.rm().addFilepattern(noteFileName).call();
+      git.add().addFilepattern(newNoteFileName).call();
       git.commit().setMessage("Move note " + noteId + " from " + noteFileName + " to " +
           newNoteFileName).call();
     } catch (GitAPIException e) {
@@ -104,9 +104,9 @@ public class GitNotebookRepo extends VFSNotebookRepo implements NotebookRepoWith
   public void move(String folderPath, String newFolderPath,
                    AuthenticationInfo subject) throws IOException {
     super.move(folderPath, newFolderPath, subject);
-    git.rm().addFilepattern(folderPath.substring(1));
-    git.add().addFilepattern(newFolderPath.substring(1));
     try {
+      git.rm().addFilepattern(folderPath.substring(1)).call();
+      git.add().addFilepattern(newFolderPath.substring(1)).call();
       git.commit().setMessage("Move folder " + folderPath + " to " + newFolderPath).call();
     } catch (GitAPIException e) {
       throw new IOException(e);

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
@@ -130,7 +130,7 @@ public class GitNotebookRepo extends VFSNotebookRepo implements NotebookRepoWith
                              String commitMessage,
                              AuthenticationInfo subject) throws IOException {
     String noteFileName = buildNoteFileName(noteId, notePath);
-    Revision revision = Revision.EMPTY;
+    Revision revision = new Revision();
     try {
       List<DiffEntry> gitDiff = git.diff().call();
       boolean modified = gitDiff.parallelStream().anyMatch(diffEntry -> diffEntry.getNewPath().equals(noteFileName));

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
@@ -24,13 +24,17 @@ import com.teragrep.zep_01.user.AuthenticationInfo;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
+import org.eclipse.jgit.diff.DiffConfig;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.dircache.DirCache;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.FollowFilter;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,25 +193,30 @@ public class GitNotebookRepo extends VFSNotebookRepo implements NotebookRepoWith
     }
     return note;
   }
-
   @Override
   public List<Revision> revisionHistory(String noteId,
                                         String notePath,
                                         AuthenticationInfo subject) throws IOException {
-    List<Revision> history = new ArrayList<>();
-    String noteFileName = buildNoteFileName(noteId, notePath);
-    LOGGER.debug("Listing history for {}:", noteFileName);
-    try {
-      Iterable<RevCommit> logs = git.log().addPath(noteFileName).call();
-      for (RevCommit log: logs) {
-        history.add(new Revision(log.getName(), log.getShortMessage(), log.getCommitTime()));
-        LOGGER.debug(" - ({},{},{})", log.getName(), log.getCommitTime(), log.getFullMessage());
+    final List<Revision> history = new ArrayList<>();
+    final String noteFileName = buildNoteFileName(noteId, notePath);
+
+    // git.log() command doesn't follow files through renames, so we use a RevWalk with a FollowFilter
+    final Repository repository = git.getRepository();
+    try (RevWalk walk = new RevWalk(repository)) {
+      final Config config = new Config();
+      final DiffConfig diffConfig = config.get(DiffConfig.KEY);
+      final FollowFilter followFilter = FollowFilter.create(noteFileName, diffConfig);
+      walk.setTreeFilter(followFilter);
+
+      // get commit from repository head if it exists and walk through every commit. FollowFilter adds commits to renamed files.
+      final ObjectId headId = repository.resolve(Constants.HEAD);
+      if (headId != null) {
+        final RevCommit startCommit = walk.parseCommit(headId);
+        walk.markStart(startCommit);
+        for (RevCommit commit : walk) {
+          history.add(new Revision(commit.getId().getName(),commit.getFullMessage(),commit.getCommitTime()));
+        }
       }
-    } catch (NoHeadException e) {
-      //when no initial commit exists
-      LOGGER.warn("No Head found for {}, {}", noteFileName, e.getMessage());
-    } catch (GitAPIException e) {
-      LOGGER.error("Failed to get logs for {}", noteFileName, e);
     }
     return history;
   }

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepo.java
@@ -199,6 +199,7 @@ public class GitNotebookRepo extends VFSNotebookRepo implements NotebookRepoWith
                                         AuthenticationInfo subject) throws IOException {
     final List<Revision> history = new ArrayList<>();
     final String noteFileName = buildNoteFileName(noteId, notePath);
+    LOGGER.debug("Listing history for {}:", noteFileName);
 
     // git.log() command doesn't follow files through renames, so we use a RevWalk with a FollowFilter
     final Repository repository = git.getRepository();
@@ -215,7 +216,11 @@ public class GitNotebookRepo extends VFSNotebookRepo implements NotebookRepoWith
         walk.markStart(startCommit);
         for (RevCommit commit : walk) {
           history.add(new Revision(commit.getId().getName(),commit.getFullMessage(),commit.getCommitTime()));
+          LOGGER.debug(" - ({},{},{})", commit.getName(), commit.getCommitTime(), commit.getFullMessage());
         }
+      }
+      else {
+        LOGGER.warn("No Head found for {}", noteFileName);
       }
     }
     return history;

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/NotebookRepoWithVersionControl.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/NotebookRepoWithVersionControl.java
@@ -80,38 +80,4 @@ public interface NotebookRepoWithVersionControl extends NotebookRepo {
   @ZeppelinApi Note setNoteRevision(String noteId, String notePath, String revId,
                                     AuthenticationInfo subject) throws IOException;
 
-  /**
-   * Represents the 'Revision' a point in life of the notebook
-   */
-  final class Revision {
-    public static final Revision EMPTY = new Revision(StringUtils.EMPTY, StringUtils.EMPTY, 0);
-
-    public final String id;
-    public final String message;
-    public final int time;
-
-    public Revision(String revId, String message, int time) {
-      this.id = revId;
-      this.message = message;
-      this.time = time;
-    }
-
-    public static boolean isEmpty(Revision revision) {
-      return revision == null || EMPTY.equals(revision);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      Revision revision = (Revision) o;
-      return time == revision.time && Objects.equals(id, revision.id) && Objects.equals(message, revision.message);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(id, message, time);
-    }
-  }
-
 }

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/NotebookRepoWithVersionControl.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/NotebookRepoWithVersionControl.java
@@ -24,6 +24,7 @@ import com.teragrep.zep_01.user.AuthenticationInfo;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Notebook repository (persistence layer) abstraction
@@ -82,12 +83,12 @@ public interface NotebookRepoWithVersionControl extends NotebookRepo {
   /**
    * Represents the 'Revision' a point in life of the notebook
    */
-  class Revision {
+  final class Revision {
     public static final Revision EMPTY = new Revision(StringUtils.EMPTY, StringUtils.EMPTY, 0);
 
-    public String id;
-    public String message;
-    public int time;
+    public final String id;
+    public final String message;
+    public final int time;
 
     public Revision(String revId, String message, int time) {
       this.id = revId;
@@ -97,6 +98,19 @@ public interface NotebookRepoWithVersionControl extends NotebookRepo {
 
     public static boolean isEmpty(Revision revision) {
       return revision == null || EMPTY.equals(revision);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Revision revision = (Revision) o;
+      return time == revision.time && Objects.equals(id, revision.id) && Objects.equals(message, revision.message);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, message, time);
     }
   }
 

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/Revision.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/Revision.java
@@ -8,11 +8,14 @@ public final class Revision {
 /**
  * Represents the 'Revision' a point in life of the notebook
  */
-    public static final Revision EMPTY = new Revision(StringUtils.EMPTY, StringUtils.EMPTY, 0);
 
     public final String id;
     public final String message;
     public final int time;
+
+    public Revision() {
+        this(StringUtils.EMPTY, StringUtils.EMPTY, 0);
+    }
 
     public Revision(final String revId, final String message, final int time) {
         this.id = revId;
@@ -21,7 +24,7 @@ public final class Revision {
     }
 
     public boolean isEmpty() {
-        return this.equals(EMPTY);
+        return (id.equals(StringUtils.EMPTY) && message.equals(StringUtils.EMPTY) && time == 0);
     }
 
     @Override

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/Revision.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/Revision.java
@@ -24,7 +24,7 @@ public final class Revision {
     }
 
     public boolean isEmpty() {
-        return (id.equals(StringUtils.EMPTY) && message.equals(StringUtils.EMPTY) && time == 0);
+        return (id.isEmpty() && message.isEmpty() && time == 0);
     }
 
     @Override

--- a/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/Revision.java
+++ b/zeppelin-zengine/src/main/java/com/teragrep/zep_01/notebook/repo/Revision.java
@@ -1,0 +1,39 @@
+package com.teragrep.zep_01.notebook.repo;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+public final class Revision {
+/**
+ * Represents the 'Revision' a point in life of the notebook
+ */
+    public static final Revision EMPTY = new Revision(StringUtils.EMPTY, StringUtils.EMPTY, 0);
+
+    public final String id;
+    public final String message;
+    public final int time;
+
+    public Revision(final String revId, final String message, final int time) {
+        this.id = revId;
+        this.message = message;
+        this.time = time;
+    }
+
+    public boolean isEmpty() {
+        return this.equals(EMPTY);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final Revision revision = (Revision) o;
+        return time == revision.time && Objects.equals(id, revision.id) && Objects.equals(message, revision.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, message, time);
+    }
+}

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/NotebookTest.java
@@ -17,6 +17,7 @@
 
 package com.teragrep.zep_01.notebook;
 
+import com.teragrep.zep_01.notebook.repo.*;
 import org.apache.commons.io.IOUtils;
 import com.teragrep.zep_01.conf.ZeppelinConfiguration;
 import com.teragrep.zep_01.conf.ZeppelinConfiguration.ConfVars;
@@ -30,10 +31,6 @@ import com.teragrep.zep_01.interpreter.InterpreterOption;
 import com.teragrep.zep_01.interpreter.InterpreterResult;
 import com.teragrep.zep_01.interpreter.InterpreterSetting;
 import com.teragrep.zep_01.interpreter.remote.RemoteInterpreter;
-import com.teragrep.zep_01.notebook.repo.NotebookRepo;
-import com.teragrep.zep_01.notebook.repo.NotebookRepoSettingsInfo;
-import com.teragrep.zep_01.notebook.repo.NotebookRepoWithVersionControl;
-import com.teragrep.zep_01.notebook.repo.VFSNotebookRepo;
 import com.teragrep.zep_01.notebook.scheduler.QuartzSchedulerService;
 import com.teragrep.zep_01.resource.LocalResourcePool;
 import com.teragrep.zep_01.scheduler.Job;

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
@@ -35,7 +35,6 @@ import com.teragrep.zep_01.interpreter.InterpreterFactory;
 import com.teragrep.zep_01.notebook.Note;
 import com.teragrep.zep_01.notebook.NoteInfo;
 import com.teragrep.zep_01.notebook.Paragraph;
-import com.teragrep.zep_01.notebook.repo.NotebookRepoWithVersionControl.Revision;
 import com.teragrep.zep_01.user.AuthenticationInfo;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -439,10 +438,5 @@ public class GitNotebookRepoTest {
     // try failure case - set to invalid revision
     returnedNote = notebookRepo.setNoteRevision(note.getId(), note.getPath(), "nonexistent_id", null);
     assertThat(returnedNote).isNull();
-  }
-
-  @Test
-  public void testContract() {
-    EqualsVerifier.forClass(NotebookRepoWithVersionControl.Revision.class).verify();
   }
 }

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
@@ -146,7 +146,7 @@ public class GitNotebookRepoTest {
     assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, TEST_NOTE_PATH, null).size()).isEqualTo(2);
     assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID2, TEST_NOTE_PATH2, null).size()).isEqualTo(1);
     assertThat(notebookRepo.checkpoint(TEST_NOTE_ID2, TEST_NOTE_PATH2, "first commit, note2", null))
-      .isEqualTo(Revision.EMPTY);
+      .isEqualTo(new Revision());
     assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID2, TEST_NOTE_PATH2, null).size()).isEqualTo(1);
 
     //modify, save and checkpoint second note

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
@@ -43,6 +43,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -218,6 +219,58 @@ public class GitNotebookRepoTest {
       revCountAfter++;
     }
     assertThat(revCountAfter).isEqualTo(revCountBefore);
+  }
+
+  @Test
+  public void testRevisionHistoryThroughRenames(){
+    notebookRepo = Assertions.assertDoesNotThrow(()->new GitNotebookRepo(conf));
+
+    // create first commit
+    Assertions.assertDoesNotThrow(()->notebookRepo.checkpoint(TEST_NOTE_ID, TEST_NOTE_PATH, "first commit", null));
+
+    // create second commit
+    final Note note = Assertions.assertDoesNotThrow(()->notebookRepo.get(TEST_NOTE_ID, TEST_NOTE_PATH, null));
+    note.setInterpreterFactory(mock(InterpreterFactory.class));
+    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    final Map<String, Object> config = p.getConfig();
+    config.put("enabled", true);
+    p.setConfig(config);
+    p.setText("%md additional paragraph");
+    Assertions.assertDoesNotThrow(()->notebookRepo.save(note, null));
+    Assertions.assertDoesNotThrow(()->notebookRepo.checkpoint(TEST_NOTE_ID, TEST_NOTE_PATH, "second commit", null));
+
+    // notebook should contain two revisions
+    final List<Revision> revisions = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, TEST_NOTE_PATH, null));
+    Assertions.assertEquals(2,revisions.size());
+
+    // rename notebook
+    final String renamedNotePath = "/my-project/my-renamed-note";
+    Assertions.assertDoesNotThrow(()->notebookRepo.move(TEST_NOTE_ID, TEST_NOTE_PATH,renamedNotePath,null));
+
+    // renamed notebook should have identical commits with the original
+    final List<Revision> renamedRevisions = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, renamedNotePath, null));
+    final List<Revision> originalRevisions = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, TEST_NOTE_PATH, null));
+    Assertions.assertEquals(3,renamedRevisions.size());
+    Assertions.assertEquals(3,originalRevisions.size());
+    for (int i = 0; i < 3; i++) {
+      Assertions.assertEquals(originalRevisions.get(i).id,renamedRevisions.get(i).id);
+    }
+
+    // Add a new commit to renamed note
+    final Note renamedNote = Assertions.assertDoesNotThrow(()->notebookRepo.get(TEST_NOTE_ID, renamedNotePath, null));
+    renamedNote.setInterpreterFactory(mock(InterpreterFactory.class));
+    final Paragraph p2 = renamedNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    p2.setText("%md adding more paragraphs");
+    Assertions.assertDoesNotThrow(()->notebookRepo.save(renamedNote, null));
+    Assertions.assertDoesNotThrow(()->notebookRepo.checkpoint(TEST_NOTE_ID, renamedNotePath, "third commit", null));
+
+    // renamed notebook should retain the two revisions from the original
+    final List<Revision> renamedRevisions2 = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, renamedNotePath, null));
+    Assertions.assertEquals(4,renamedRevisions2.size());
+
+    // original notebook should not have revisions that concern the renamed notebook
+    final List<Revision> originalRevisions2 = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, TEST_NOTE_PATH, null));
+    Assertions.assertEquals(3,originalRevisions2.size());
   }
 
   private boolean containsNote(Map<String, NoteInfo> notes, String noteId) {

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/GitNotebookRepoTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.truth.Truth;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import com.teragrep.zep_01.conf.ZeppelinConfiguration;
@@ -250,11 +251,7 @@ public class GitNotebookRepoTest {
     // renamed notebook should have identical commits with the original
     final List<Revision> renamedRevisions = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, renamedNotePath, null));
     final List<Revision> originalRevisions = Assertions.assertDoesNotThrow(()->notebookRepo.revisionHistory(TEST_NOTE_ID, TEST_NOTE_PATH, null));
-    Assertions.assertEquals(3,renamedRevisions.size());
-    Assertions.assertEquals(3,originalRevisions.size());
-    for (int i = 0; i < 3; i++) {
-      Assertions.assertEquals(originalRevisions.get(i).id,renamedRevisions.get(i).id);
-    }
+    Assertions.assertEquals(renamedRevisions, originalRevisions);
 
     // Add a new commit to renamed note
     final Note renamedNote = Assertions.assertDoesNotThrow(()->notebookRepo.get(TEST_NOTE_ID, renamedNotePath, null));
@@ -442,5 +439,10 @@ public class GitNotebookRepoTest {
     // try failure case - set to invalid revision
     returnedNote = notebookRepo.setNoteRevision(note.getId(), note.getPath(), "nonexistent_id", null);
     assertThat(returnedNote).isNull();
+  }
+
+  @Test
+  public void testContract() {
+    EqualsVerifier.forClass(NotebookRepoWithVersionControl.Revision.class).verify();
   }
 }

--- a/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/RevisionTest.java
+++ b/zeppelin-zengine/src/test/java/com/teragrep/zep_01/notebook/repo/RevisionTest.java
@@ -1,0 +1,27 @@
+package com.teragrep.zep_01.notebook.repo;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public final class RevisionTest {
+
+    @Test
+    public void testIsEmpty(){
+        final String id = "id";
+        final String message = "message";
+        final int time = 178300000;
+        final Revision revision = new Revision(id,message,time);
+        Assertions.assertFalse(revision.isEmpty());
+
+        final String emptyId = "";
+        final String emptyMessage = "";
+        final int emptyTime = 0;
+        final Revision emptyRevision = new Revision(emptyId,emptyMessage,emptyTime);
+        Assertions.assertTrue(emptyRevision.isEmpty());
+    }
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(Revision.class).verify();
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where version history does not persist through renaming of a notebook by swapping usage of git.log() in GitNotebookRepo to using a RevWalk with a FollowFilter, which does keep track of renaming.

fixes #330 
## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
